### PR TITLE
Wiki/Advanced-Usage: update example output from `--config-show`

### DIFF
--- a/wiki/Advanced-Usage.md
+++ b/wiki/Advanced-Usage.md
@@ -341,11 +341,12 @@ To view the currently set configuration options, use the `--config-show` command
 
 ```bash
 $ phpcs --config-show
-Array
-(
-    [default_standard] => PEAR
-    [zend_ca_path] => /path/to/ZendCodeAnalyzer
-)
+
+Using config file: path/to/PHP_CodeSniffer/CodeSniffer.conf
+
+colors:           1
+default_standard: PEAR
+report_width:     150
 ```
 
 <p align="right"><a href="#table-of-contents">back to top</a></p>


### PR DESCRIPTION
As the PHPCS installation used in GH Actions won't have a `CodeSniffer.conf` file yet, this cannot be automated.
Aside from that, automating this would yield inconsistent results when contributors would run the command output replacement script locally.

Replacing it now with a manually crafted, updated output example.