### PR TITLE
GH Actions: add basic QA workflow

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -1,0 +1,53 @@
+$schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+version: '0.2'
+language: en-GB
+readonly: true
+
+useGitignore: true
+
+dictionaries:
+  - php
+
+patterns:
+  - name: markdown_code_block
+    pattern: |
+      /
+          ^(\s*`{3,})[a-z]+   # match the ``` with a language modifier
+          [\s\S]*?            # the block of code
+          ^\1                 # end of the block
+      /gmx
+  - name: markdown_inline_code
+    pattern: /(\s*`)[^`\n]{3,}`/gmx
+
+languageSettings:
+  - languageId: markdown
+    ignoreRegExpList:
+      - markdown_code_block
+      - markdown_inline_code
+
+words:
+  # Generic "good" words.
+  - PHP_CodeSniffer
+  - phpcs
+  - phpcbf
+  - Allman
+  - Analyzer
+  - anymore
+  - csslint
+  - docblocks
+  - gitblame
+  - gjslint
+  - Joomla
+  - nowdocs
+  - Squiz
+  - SquizLabs
+
+  # Used in Wiki Reporting page, "gitblame" report.
+  - jsmith
+  - jblogs
+  - pdeveloper
+  - jscript
+  - toogood
+
+  # Used in Wiki Reporting page, "emacs" file.
+  - defun

--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -1,0 +1,80 @@
+name: CS
+
+on:
+  # Run on all pushes and on all pull requests.
+  push:
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Do NOT cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  yamllint:
+    name: 'Lint Yaml'
+    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
+    with:
+      strict: true
+
+  markdownlint:
+    name: 'Lint Markdown'
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
+
+  linkcheck:
+    name: "Check links"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --cache --max-cache-age 1w --verbose "./**/*.md"
+          format: markdown
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fail: true
+
+  spellcheck:
+    name: Spellcheck
+    # Config file: .cspell.yml
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Spellcheck
+        id: spellcheck
+        continue-on-error: true
+        uses: streetsidesoftware/cspell-action@v7
+        with:
+          # Define glob patterns to filter the files to be checked. Use a new line between patterns to define multiple patterns.
+          files: '**/*.md'
+          root: '.'
+          suggestions: true
+          # Notification level for annotations. Allowed values are: warning, error, none
+          inline: warning
+          treat_flagged_words_as_errors: true
+          # Determines if the action should be failed if any spelling issues are found.
+          strict: true
+          # Limit the files checked to the ones in the pull request or push.
+          incremental_files_only: false
+
+      # Note: if less issues than expected were found, these numbers should be updated in the PR which fixes the issues!
+      - name: Fail the build when more spelling issues were found than expected
+        if: ${{ always() && ( steps.spellcheck.outputs.number_of_issues != 3 || steps.spellcheck.outputs.number_of_files_with_issues != 2 ) }}
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.lycheecache
 _wiki/
+node_modules/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,129 @@
+#
+# Configuration file for MarkdownLint-CLI2.
+#
+# Example file with all options:
+# https://github.com/DavidAnson/markdownlint-cli2/blob/main/test/markdownlint-cli2-yaml-example/.markdownlint-cli2.yaml
+# Example file with all rules:
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+#
+
+# Define glob expressions to use (only valid at root).
+globs:
+  - "**/*.md"
+
+# Show found files on stdout (only valid at root).
+showFound: true
+
+# Define glob expressions to ignore.
+ignores:
+
+# Disable inline config comments.
+noInlineConfig: true
+
+# Disable progress on stdout (only valid at root).
+noProgress: false
+
+# Adjust the configuration for some built-in rules.
+# For full information on the options and defaults, see:
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+config:
+  ######################
+  # Disable a few rules.
+  ######################
+  # MD014/commands-show-output : Dollar signs used before commands without showing output.
+  MD014: false
+  # MD028/no-blanks-blockquote : Blank line inside blockquote.
+  MD028: false
+  # MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines.
+  MD031: false
+  # MD032/blanks-around-lists - Lists should be surrounded by blank lines.
+  MD032: false
+  # MD036/no-emphasis-as-heading : Emphasis used instead of a heading.
+  # Disabled as this is used as a "hack" to exclude select headers from the automatic Table of Contents creation.
+  MD036: false
+  # MD041/first-line-heading/first-line-h1 : First line in a file should be a top-level heading.
+  MD041: false
+
+  ##############################
+  # Customize a few other rules.
+  ##############################
+  # MD003/heading-style/header-style - Heading style.
+  MD003:
+    # Heading style - Always use hashes.
+    style: "atx"
+
+  # MD007/ul-indent - Unordered list indentation.
+  MD007:
+    indent: 4
+    # Whether to indent the first level of the list.
+    start_indented: false
+
+  # MD012/no-multiple-blanks - Multiple consecutive blank lines.
+  MD012:
+    maximum: 2
+
+  # MD013/line-length - Line length.
+  MD013:
+    # Number of characters. No need for being too fussy.
+    line_length: 1000
+    # Number of characters for headings.
+    heading_line_length: 100
+    # Number of characters for code blocks.
+    code_block_line_length: 120
+    # Include code blocks.
+    code_blocks: false
+    # Stern length checking (applies to tables, code blocks etc which have their own max line length).
+    stern: true
+
+  # MD022/blanks-around-headings : Headings should be surrounded by blank lines.
+  MD022:
+    # Blank lines above heading.
+    lines_above: [2, 1, 1, 1, 1]
+    # Blank lines below heading.
+    lines_below: [1, 1, 1, -1, -1]
+
+  # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content.
+  MD024:
+    # Only check sibling headings.
+    siblings_only: true
+
+  # MD026/no-trailing-punctuation : Trailing punctuation in heading.
+  MD026:
+    # Punctuation characters
+    punctuation: ".,;。，；：！"
+
+  # MD033/no-inline-html - Inline HTML.
+  MD033:
+    # Allowed elements.
+    allowed_elements:
+      - div
+      - p
+      - a
+
+  # MD044/proper-names - Proper names should have the correct capitalization.
+  MD044:
+    # List of proper names.
+    names: ["PHP_CodeSniffer", "CodeSniffer", "PHPCSUtils", "PHPCSExtra", "PHPUnit", "Xdebug"]
+    # Include code blocks.
+    code_blocks: false
+
+  # MD046/code-block-style - Code block style.
+  MD046:
+    style: "fenced"
+
+  # MD048/code-fence-style - Code fence style.
+  MD048:
+    style: "backtick"
+
+  # MD049/emphasis-style - Emphasis style should be consistent.
+  MD049:
+    style: "underscore"
+
+  # MD050/strong-style - Strong style should be consistent.
+  MD050:
+    style: "asterisk"
+
+  # MD055/table-pipe-style : Table pipe style.
+  MD055:
+    # Table pipe style.
+    style: "leading_and_trailing"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,22 @@
+# Details on the default config:
+# https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+# Rule documentation: https://yamllint.readthedocs.io/en/stable/rules.html
+rules:
+  colons:
+    max-spaces-after: -1  # Disabled to allow aligning of values.
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: {}
+  document-start:
+    present: false
+  line-length:
+    max: 145
+  truthy:
+    allowed-values: ["true", "false", "on", "off"]


### PR DESCRIPTION
* Lint Yaml files, including linting GH action workflows for common issues.
* Lint markdown for consistent code style.
* Check markdown files against broken links.
* Check spelling in the files.

Includes documenting what is being checked for via configuration files. This also ensures that most checks can be run locally by contributors.

Note: the spellcheck currently has a tolerance for three pre-existing issues. These will be fixed in the updates related to PHPCS 4.0.

Refs:
* https://github.com/DavidAnson/markdownlint-cli2/
* https://github.com/DavidAnson/markdownlint/
* https://yamllint.readthedocs.io/
* https://github.com/rhysd/actionlint
* https://github.com/lycheeverse/lychee-action
* https://github.com/streetsidesoftware/cspell-action