### PR TITLE
GH Actions: automate some issue/PR label management 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+version: 1
+appendOnly: true
+labels:
+  - label: "Status: triage"
+    draft: false
+    author-can-merge: false
+
+  - label: "Component: Website"
+    draft: false
+    files:
+      - "src/.*"
+
+  - label: "Component: Wiki"
+    draft: false
+    files:
+      - "build/wiki-command-replacer.sh"
+      - "build/wiki-code-samples/.*"
+      - "wiki/.*"
+
+  - label: "Type: chores/QA/automation"
+    draft: false
+    files:
+      - ".yamllint.yml"
+      - ".github/.*"
+      - "build/wiki-command-replacer.sh"

--- a/.github/workflows/label-new-prs.yml
+++ b/.github/workflows/label-new-prs.yml
@@ -1,0 +1,49 @@
+name: Label new PRs
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  # The `pull_request_target` event is used for "normal" PRs to label them when they are opened.
+  # This will use the `labeler.yml` file in the default (main) branch of the repo.
+  pull_request_target:
+    types:
+      - opened
+      - ready_for_review
+
+  # The `pull_request` event is used for PRs which change the files which handle the labeling to prevent a silently failing action.
+  # This will use the `labeler.yml` file in the PR branch.
+  pull_request:
+    paths:
+      - '.github/workflows/label-new-prs.yml'
+      - '.github/labeler.yml'
+
+jobs:
+  label-new-prs:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCSStandards' && github.event_name == 'pull_request_target'
+
+    name: Add labels to new PRs
+
+    steps:
+      - name: Label new PRs
+        uses: srvaroa/labeler@v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  validate-labeler-worflow:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCSStandards' && github.event_name == 'pull_request' && github.event.pull_request.merged == false
+
+    name: Validate changes to Labeler logic
+
+    steps:
+      # Checkout is needed to use the `use_local_config` option.
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify changes to the labeling logic
+        uses: srvaroa/labeler@v1
+        with:
+          use_local_config: true
+          fail_on_error: true
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label-remove-outdated.yml
+++ b/.github/workflows/label-remove-outdated.yml
@@ -1,0 +1,79 @@
+name: Remove outdated labels
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  issues:
+    types:
+      - closed
+  pull_request_target:
+    types:
+      - closed
+      - review_requested
+
+jobs:
+  on-issue-close:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCSStandards' && github.event.issue.state == 'closed'
+
+    name: Clean up labels on issue close
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            Status: awaiting feedback
+            Status: close candidate
+            Status: help wanted
+            Status: needs investigation
+            Status: triage
+
+  on-pr-review-request:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCSStandards' && github.event.action == 'review_requested'
+
+    name: "Clean up labels on PR (re-)review request"
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            Status: awaiting feedback
+
+  on-pr-merge:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCSStandards' && github.event.pull_request.merged == true
+
+    name: Clean up labels on PR merge
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            Status: awaiting feedback
+            Status: close candidate
+            Status: has merge conflict
+            Status: help wanted
+            Status: needs investigation
+            Status: triage
+            Status: wait for PHPCS 4.0.0 release
+
+  on-pr-close:
+    runs-on: ubuntu-latest
+    # yamllint disable-line rule:line-length
+    if: github.repository_owner == 'PHPCSStandards' && github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == false
+
+    name: Clean up labels on PR close
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            Status: awaiting feedback
+            Status: close candidate
+            Status: help wanted
+            Status: needs investigation
+            Status: triage


### PR DESCRIPTION
# Description

### GH Actions: auto-label new PRs 

Similar workflow as the one used in the main PHP_CodeSniffer repo to auto-apply some labels based on the contents of new PRs.

Ref: https://github.com/srvaroa/labeler

### GH Actions: automate some label management 

This is a quite straight-forward workflow to just remove some labels which should only be on open issues/open PRs and which should be removed once an issue or PR has been closed/merged.

Just attempting to reduce some manual labour.
