### PR TITLE
GH Actions/publish-wiki: update path selection

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -4,13 +4,17 @@ on:
     branches:
       - 'main'
     paths:
-      - wiki/**
       - .github/workflows/publish-wiki.yml
+      - build/wiki-code-samples/**
+      - build/wiki-command-replacer.sh
+      - wiki/**
   # Do a dry-run (check, no deploy) for PRs.
   pull_request:
     paths:
-      - wiki/**
       - .github/workflows/publish-wiki.yml
+      - build/wiki-code-samples/**
+      - build/wiki-command-replacer.sh
+      - wiki/**
   # Allow running this workflow manually from the Actions tab.
   workflow_dispatch:
   # Allow this workflow to be triggered from outside.


### PR DESCRIPTION
# Description

I forgot to update the path selection in the `publish-wiki` workflow in PR #20, but this workflow should definitely also do a PR dry-run/push deploy if the automation to update the output example blocks changes.

