### PR TITLE
GH Actions/publish-wiki: use PAT for commenting on PRs

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -130,8 +130,10 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: mshick/add-pr-comment@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.COMMENT_ON_PRS_TOKEN }}
           message: |
+            **_=== This is an auto-generated comment ===_**
+
             Thank you for your PR.
             A dry-run has been executed on your PR, executing all markdown pre-processing for the wiki files.
 


### PR DESCRIPTION
# Description
In the original PR (#6), a Personal Access Token (PAT) was used, but that resulted in the comment being left as if coming from my account, which is misleading, which is why the `repo_token` was initially switched back to `secrets.GITHUB_TOKEN`, with a reminder that a test would need to be done with a PR coming from a fork to verify that the auto-comment would still work.

As the first PR from a fork has now come in (#38), it has become clear that the auto-comment does not work with the default GitHub token, so this commit switches the `repo_token` back to the Personal Access Token and updates the message to make it clear I did not leave the comment.

We'll still have to test (again) whether using the PAT works for PRs coming from forks. If not, we'll have to revisit this workflow step.


