### PR TITLE
GH Actions: fix PR comment conundrum

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,91 @@
+name: Pull Request Comment
+
+on:
+  workflow_run:
+    workflows: ['Publish wiki']
+    types:
+      - completed
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.sha }}
+
+jobs:
+  artifact-review-comment:
+    if: >
+      github.repository == 'PHPCSStandards/PHP_CodeSniffer-documentation' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Needed for the PR comment.
+      pull-requests: write
+
+    name: Comment on a pull request
+
+    steps:
+      - name: Download PR info artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+
+            const matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_info"
+            })[0];
+
+            if ( ! matchArtifact ) {
+              core.setFailed( 'No artifact found!' );
+              return;
+            }
+
+            const download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+
+            const fs = require( 'fs' );
+            fs.writeFileSync( '${{ github.workspace }}/pr_info.zip', Buffer.from( download.data ) )
+
+      - name: Unzip PR info artifact
+        run: unzip pr_info.zip
+
+      - name: Read PR number
+        id: pr_number
+        shell: bash
+        run: |
+          value=$(<"pr_number")
+          echo "PR_NR=$value" >> "$GITHUB_OUTPUT"
+
+      - name: Read Wiki artifact URL
+        id: artifact_url
+        shell: bash
+        run: |
+          value=$(<"artifact_url")
+          echo "URL=$value" >> "$GITHUB_OUTPUT"
+
+      - name: "Post comment to review artifact"
+        uses: mshick/add-pr-comment@v2
+        with:
+          issue: ${{ steps.pr_number.outputs.PR_NR }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            **_=== This is an auto-generated comment ===_**
+
+            Thank you for your PR.
+            A dry-run has been executed on your PR, executing all markdown pre-processing for the wiki files.
+
+            Please review the resulting final markdown files via the [created artifact](${{ steps.artifact_url.outputs.URL }}).
+            This is especially important when adding new pages or updating auto-generated output blocks.
+
+            _N.B.: the above link will automatically be updated when this PR is updated._

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
     paths:
       - .github/workflows/publish-wiki.yml
+      - .github/workflows/pr-comment.yml
       - build/wiki-code-samples/**
       - build/wiki-command-replacer.sh
       - wiki/**
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/publish-wiki.yml
+      - .github/workflows/pr-comment.yml
       - build/wiki-code-samples/**
       - build/wiki-command-replacer.sh
       - wiki/**
@@ -38,8 +40,6 @@ jobs:
     permissions:
       # Needed for the commit to the wiki.
       contents: write
-      # Needed for the PR comment.
-      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -126,22 +126,6 @@ jobs:
           if-no-files-found: error
           retention-days: 10
 
-      - name: "[PR only] Post comment to review artifact"
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: mshick/add-pr-comment@v2
-        with:
-          repo-token: ${{ secrets.COMMENT_ON_PRS_TOKEN }}
-          message: |
-            **_=== This is an auto-generated comment ===_**
-
-            Thank you for your PR.
-            A dry-run has been executed on your PR, executing all markdown pre-processing for the wiki files.
-
-            Please review the resulting final markdown files via the [created artifact](${{ steps.artifact.outputs.artifact-url }}).
-            This is especially important when adding new pages or updating auto-generated output blocks.
-
-            _N.B.: the above link will automatically be updated when this PR is updated._
-
 
       # ################################################################################
       # Deploy to the wiki in the PHPCS repo.
@@ -153,6 +137,7 @@ jobs:
           git_threshold: partial_outage
 
       - name: Deploy to wiki
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: Andrew-Chen-Wang/github-wiki-action@v5.0.1
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
@@ -166,3 +151,31 @@ jobs:
           dry-run: ${{ github.event_name == 'pull_request' }}
           disable-empty-commits: true
           preprocess: false
+
+
+      # ################################################################################
+      # Dry-run/PRs: save PR info for use in Pull Request Comment workflow.
+      # ################################################################################
+
+      - name: Create temporary directory
+        if: ${{ github.event_name == 'pull_request' }}
+        run: mkdir -p ./pr
+
+      - name: Save PR number
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: echo "${PR_NUMBER}" > ./pr/pr_number
+
+      - name: Save artifact URL
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          ARTIFACT_URL: ${{ steps.artifact.outputs.artifact-url }}
+        run: echo "${ARTIFACT_URL}" > ./pr/artifact_url
+
+      - name: Upload PR info as artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_info
+          path: pr/


### PR DESCRIPTION
# Description

As described in issue #42, the PR comment to review the pre-processed wiki files was not being posted on PRs coming from forks, while it is all the more relevant for those, as outside contributors may not be aware of the artifact with the wiki files being available.

I've now done some more research into this and believe the changes in this PR will fix this.

The most important take-away from my research is as follows:
* Workflows triggered by a PR from a fork only have "read" access via the `secrets.GITHUB_TOKEN` and no access to Personal Access Tokens.
* However, workflows can trigger other workflows and those "follow-on" workflows **_can_** have "write" access via the `secrets.GITHUB_TOKEN` as they are run in the context of the `main` branch, not in the context of the PR branch (which is also why I had to briefly use `main` to test this PR).

So, with that in mind, I've moved the "comment on PR" step to a separate workflow which is triggered once the "Publish wiki" workflow has completed and will only run for pull requests.

This new workflow had access to the artifacts created by the triggering workflow, but doesn't have access to much else, while it needs access to the PR number of the PR which triggered the workflow cascade + access to the download URL for the wiki files artifact.

Those pieces of information are both available in the "triggering workflow", so we need to store them in - you guessed it - an artifact, so that info can then be retrieved by the second (PR comment) workflow.

Other notes:
* The "Deploy to wiki" dry-run was failing for PRs from forks (though this was hidden by the earlier step for the comment failing) with the following error: `fatal: could not read Username for 'https://github.com': No such device or address`.
    As the "Deploy to wiki" step needs a Personal Access Token for the push to the wiki, this is no great surprise, what with PRs from forks not having access to the PAT.
    Switching to the `secrets.GITHUB_TOKEN` just and only for the dry-run, unfortunately would still fail for PRs from works, so I've now made the "Deploy to wiki" step conditional on the workflow either not being triggered by a PR _or_ the PR not coming from a fork.

## Related issues/external references

Fixes #42

Refs:
* https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#using-data-from-the-triggering-workflow

## Additional info

I've tested this by briefly adding just the new `pr-comment.yml` workflow to the `main` branch and then rebasing this PR on top of the "temporary" `main` branch. As can be seen via the below comment, the workflow changes are working (keep in mind, this PR is coming from a fork to allow for testing this change).
