### PR TITLE
Minor fixes and adjustments to the PHPCS 4.0 upgrade guides

### DIFF
--- a/wiki/Version-4.0-Developer-Upgrade-Guide.md
+++ b/wiki/Version-4.0-Developer-Upgrade-Guide.md
@@ -537,7 +537,7 @@ The Ruleset class now respects sniff selection via `--sniffs=...`, even when in 
 
 If your own test framework contained workarounds to get round the previous restriction, it should now be safe to remove those workarounds and to use the `--sniffs=...` argument when initiating the `Config` class.
 
-Typically, these types of workarounds can be found by searching for calls to the `Ruleset::registerSniffs()` method.
+Typically, these type of workarounds can be found by searching for calls to the `Ruleset::registerSniffs()` method.
 
 <p align="right"><a href="#table-of-contents">back to top</a></p>
 

--- a/wiki/Version-4.0-Developer-Upgrade-Guide.md
+++ b/wiki/Version-4.0-Developer-Upgrade-Guide.md
@@ -120,7 +120,7 @@ Type casting for sniff property values set from within a ruleset has been made m
 
 **Upgrading**
 
-Search for sniff which have `public` properties which can be changed from within a ruleset.
+Search for sniffs which have `public` properties which can be changed from within a ruleset.
 
 * If the sniff has workarounds in place to handle non-lowercase string `'true'` or `'false'` values for boolean properties, those workarounds can be removed.
 * If the sniff has workarounds in place to handle (any case) string `'null'` values, those workarounds can be removed.
@@ -174,7 +174,7 @@ For "properties" declared in enums, which is still not allowed in PHP, the metho
 
 ##### Upgrading
 
-The above is significant change in behaviour and how it needs to be handled will depend on the sniff calling the method.
+The above is a significant change in behaviour and how it needs to be handled will depend on the sniff calling the method.
 
 It is recommended to search your codebase for all uses of the `File::getMemberProperties()` method and to review whether the code needs updating.
 
@@ -194,7 +194,7 @@ Also, in all cases, the sniff may need to start taking PHP 8.4 properties on int
 
 ... and the associated `private Config::$overriddenDefaults` property is also no longer static.
 
-In practice, this means that two consecutively created `Config` objects without the same process will now contain the same settings. Previously, settings overridden in the first Config instance, could not be set for the second Config instance.
+In practice, this means that two consecutively created `Config` objects in the same process will now contain the same settings. Previously, settings overridden in the first Config instance, could not be set for the second Config instance.
 
 Typically, this may impact projects which call `new Config` consecutive times programmatically, whether it is for a custom integration or for a custom test suite.
 
@@ -403,7 +403,7 @@ doSomething();
 
 The `AbstractPatternSniff::__construct()` method no longer takes any arguments. The `$ignoreComments` parameter was deprecated in PHPCS 1.4.0.
 
-Since PHPCS 1.4.0, the  AbstractPatternSniff sets the `ignoreComments` option using a `public` var rather than through the constructor.  
+Since PHPCS 1.4.0, the AbstractPatternSniff sets the `ignoreComments` option using a `public` var rather than through the constructor.  
 This allows the setting to be overwritten in `ruleset.xml` files.
 
 **Upgrading**
@@ -462,7 +462,7 @@ The `protected` `getDeclarationNameWithNamespace()` and `getNamespaceOfScope()` 
 
 * The signature of the `DummyFile::setErrorCounts()` method has changed and now expects the following parameters: `$errorCount, $warningCount, $fixableErrorCount, $fixableWarningCount, $fixedErrorCount, $fixedWarningCount`.
 
-* The abstract `PHP_CodeSniffer\Filters\ExactMatch::getBlacklist()` and `PHP_CodeSniffer\Filters\ExactMatch::getWhitelist()` methods have been replaced with abstract `PHP_CodeSniffer\ExactMatch::getDisallowedFiles()` and `PHP_CodeSniffer\ExactMatch::getAllowedFiles()` methods.  
+* The abstract `PHP_CodeSniffer\Filters\ExactMatch::getBlacklist()` and `PHP_CodeSniffer\Filters\ExactMatch::getWhitelist()` methods have been replaced with abstract `PHP_CodeSniffer\Filters\ExactMatch::getDisallowedFiles()` and `PHP_CodeSniffer\Filters\ExactMatch::getAllowedFiles()` methods.  
     If you have custom classes which extend the `ExactMatch` class, implement the new `getDisallowedFiles()` and `getAllowedFiles()` methods instead.  
     Note: this is a name change only. The functionality remains the same.
 
@@ -537,7 +537,7 @@ The Ruleset class now respects sniff selection via `--sniffs=...`, even when in 
 
 If your own test framework contained workarounds to get round the previous restriction, it should now be safe to remove those workarounds and to use the `--sniffs=...` argument when initiating the `Config` class.
 
-Typically, these type of workarounds can be found by searching for calls to the `Ruleset::registerSniffs()` method.
+Typically, these types of workarounds can be found by searching for calls to the `Ruleset::registerSniffs()` method.
 
 <p align="right"><a href="#table-of-contents">back to top</a></p>
 

--- a/wiki/Version-4.0-User-Upgrade-Guide.md
+++ b/wiki/Version-4.0-User-Upgrade-Guide.md
@@ -97,7 +97,7 @@ To continue running code style and code quality checks on JS and/or CSS files, u
 There are two kinds of sniffs which are affected by this:
 1. Sniffs which are specific to JS/CSS and only target JS/CSS code.  
     If you use JS/CSS specific sniffs from either PHP_CodeSniffer itself or from an external standard, remove references to these sniffs from your ruleset.
-2. "Mixed" sniffs, i.e. sniffs which target both PHP as well as JS and/or CSS code.  
+2. "Mixed" sniffs, i.e., sniffs which target both PHP as well as JS and/or CSS code.  
     If an external standard you include in your ruleset contains these type of "mixed" sniffs, contact the maintainer of that standard about making the sniff compatible with PHP_CodeSniffer 4.0.
 
 PHP_CodeSniffer >= 3.13.0 will show you deprecation notices for these sniffs to help you find them.
@@ -321,7 +321,7 @@ What to update these to, depends on your use-case.
 
 ## Notable other changes and new features
 
-### Progress, error and debug output is now send to STDERR
+### Progress, error and debug output is now sent to STDERR
 
 This change should make it more straight-forward to pipe output from PHP_CodeSniffer to a file.
 
@@ -352,7 +352,7 @@ Previously a ruleset could already "extend" an array property for a sniff set by
 
 As of PHP_CodeSniffer 4.0, a ruleset can also "extend" the default value of an array property as set in the sniff itself.
 
-The upside of this is, that if you want to default value + some extras, you no longer need to duplicate the default values from sniff array properties in your ruleset.  
+The upside of this is that if you want the default value + some extras, you no longer need to duplicate the default value from a sniff array property in your ruleset.  
 The downside is, of course, that if the default value of the property in the sniff changes, your scans may start failing without warning.
 
 #### Upgrading

--- a/wiki/Version-4.0-User-Upgrade-Guide.md
+++ b/wiki/Version-4.0-User-Upgrade-Guide.md
@@ -97,7 +97,7 @@ To continue running code style and code quality checks on JS and/or CSS files, u
 There are two kinds of sniffs which are affected by this:
 1. Sniffs which are specific to JS/CSS and only target JS/CSS code.  
     If you use JS/CSS specific sniffs from either PHP_CodeSniffer itself or from an external standard, remove references to these sniffs from your ruleset.
-2. "Mixed" sniffs, i.e., sniffs which target both PHP as well as JS and/or CSS code.  
+2. "Mixed" sniffs, i.e. sniffs which target both PHP as well as JS and/or CSS code.  
     If an external standard you include in your ruleset contains these type of "mixed" sniffs, contact the maintainer of that standard about making the sniff compatible with PHP_CodeSniffer 4.0.
 
 PHP_CodeSniffer >= 3.13.0 will show you deprecation notices for these sniffs to help you find them.
@@ -352,7 +352,7 @@ Previously a ruleset could already "extend" an array property for a sniff set by
 
 As of PHP_CodeSniffer 4.0, a ruleset can also "extend" the default value of an array property as set in the sniff itself.
 
-The upside of this is that if you want the default value + some extras, you no longer need to duplicate the default value from a sniff array property in your ruleset.  
+The upside of this is that, if you want to use the default value + some extras, you no longer need to duplicate the default values from sniff array properties in your ruleset.  
 The downside is, of course, that if the default value of the property in the sniff changes, your scans may start failing without warning.
 
 #### Upgrading


### PR DESCRIPTION
# Description

This PR makes some minor fixes and adjustments to the two PHPCS 4.0 upgrade guides.

## Related issues/external references

Fixes #2 
