### PR TITLE
GH Actions: work around a bug in Lychee

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --cache --max-cache-age 1w --verbose "./**/*.md"
+          # Sidebar file exclusion is needed to work-around an upstream bug.
+          # Should be removed once bug https://github.com/lycheeverse/lychee/issues/1788 has been fixed.
+          args: --cache --max-cache-age 1w --verbose "./**/*.md" --exclude-path ./wiki/_Sidebar.md
           format: markdown
           token: ${{ secrets.GITHUB_TOKEN }}
           fail: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,7 @@ To run the quality checks locally, install the following tooling:
     * Run it like so: `markdownlint-cli2`
 * [Lychee](https://github.com/lycheeverse/lychee)
     * [Installation instructions](https://github.com/lycheeverse/lychee?tab=readme-ov-file#installation)
-    * Run it like so: `lychee "./**/*.md"`
-        Note: this command will show "false positives" locally for the `_Sidebar.md` file. These can be ignored.
+    * Run it like so: `lychee "./**/*.md" --exclude-path ./wiki/_Sidebar.md`
 * [CSpell](https://cspell.org/)
     * [Installation instructions](https://cspell.org/docs/installation)
     * Run it like so: `cspell "**/*.md"`


### PR DESCRIPTION
# Description
Wiki links with spaces are incorrectly flagged as broken since Lychee 0.19.0.

This has been reported upstream via lycheeverse/lychee#1788

For now, let's exclude the `_Sidebar.md` file from the scan to unblock contributors. This change should be undone once the upstream issue has been fixed & released.

