### PR TITLE
4.0 | Wiki/Advanced-Usage: add the cumulative exit codes

### DIFF
--- a/wiki/Advanced-Usage.md
+++ b/wiki/Advanced-Usage.md
@@ -524,16 +524,13 @@ As of PHP_CodeSniffer 4.0.0, exit codes are cumulative and composed as follows:
 | `16`      | processing error - blocking the actual run of PHP_CodeSniffer, like a parse error in an XML ruleset            |
 | `64`      | requirements for running not met (i.e. minimum PHP version doesn't comply, missing required extensions)        |
 
-Example: when running `phpcs`, if both auto-fixable as well as non-auto-fixable issues are found, the exit code will be `3` (`1` + `2`).
+The exit codes in some situations can be combined, resulting in a new exit code. These cumulative exit codes are as follows:
 
-Cumulative exit codes:
-
-| Exit code | Meaning                                                                                                        |
-|-----------|----------------------------------------------------------------------------------------------------------------|
-| `3`       | issues found, mix of auto-fixable and non-auto-fixable (`1` + `2`) (phpcs only)                                |
-| `5`       | issues found, auto-fixable, but some failed to fix (`1` + `4`) (phpcbf only)                                   |
-| `7`       | issues found, mix of auto-fixable and non-auto-fixable, but some failed to fix (`1` + `2` + `4`) (phpcbf only) |
-
+| Exit code | Exit codes used | Meaning                                                                                      |
+| --------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `3`       | `1` + `2`       | issues found, mix of auto-fixable and non-auto-fixable (phpcs only)                          |
+| `5`       | `1` + `4`       | issues found, auto-fixable, but some failed to fix (phpcbf only)                             |
+| `7`       | `1` + `2` + `4` | issues found, mix of auto-fixable and non-auto-fixable, but some failed to fix (phpcbf only) |
 
 The exit codes can be influenced by the following configuration flags: [`ignore_errors_on_exit`](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#ignoring-errors-when-generating-the-exit-code), [`ignore_warnings_on_exit`](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#ignoring-warnings-when-generating-the-exit-code) and [`ignore_non_auto_fixable_on_exit`](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#ignoring-non-auto-fixable-issues-when-generating-the-exit-code).
 


### PR DESCRIPTION
- Added the cumulative exit codes as documented in the interim proposal. This ensures a complete exit code documentation where users and devs can easily read exactly what the cumulative exit codes are.

- Added another description to the `0` exit code to describe when issues are fixed with no issues remaining, because "clean code base" could just be interpreted as no issues at all.

<!-- Provide a general summary of your changes in the title above. -->

<!--
IMPORTANT:
PRs should be small and atomic and should only focus on one thing.
There should generally only be one commit per PR for changes to the Wiki.

If your PR is making multiple distinct changes, please split it now and submit multiple PRs instead.
-->

# Description
<!--
What do you want to achieve with this PR? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->


## Related issues/external references

https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/184#issuecomment-2644329771


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation/blob/main/CONTRIBUTING.md).
- [x] I grant the project the right to include my changes under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have verified that my changes comply with the projects coding standards.
- [ ] \[When adding a new Wiki page\] I have added the new page to the `_Sidebar.md` file.
- [x] \[When adding/updating output examples\] I have verified via the GitHub Actions artifact that the pre-processing handles the command correctly.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
