### PR TITLE
Very very early draft for mail to funders about the 4.0 release

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -57,3 +57,6 @@ words:
   - maxlevel
   - replacer
   - Shellcheck
+
+  # Used in newsletters.
+  - Robbert

--- a/newsletters/202509-phpcs-4.0-release.md
+++ b/newsletters/202509-phpcs-4.0-release.md
@@ -1,0 +1,20 @@
+# PRESS RELEASE
+
+## Highlights of the 4.0 release
+
+* Root rulesets can now overrule config and CLI settings set in child rulesets.
+* Ability to scan files without extension.
+* Less chance on scans failing on parse errors during live coding.
+* Exit code improvements
+* Proper separation of output between STDOUT and STDERR.
+    Piping output to STDOUT will no longer contain progress information or error notices
+* Array properties set in a ruleset file can now extend a potential default value for the property.
+
+
+Other note worthy improvements from the past few months
+* Permalinks to XSD schema
+* The documentation Wiki is now publicly editable.
+
+
+<!-- MAYBE, but probably not appropriate for the release mail, maybe better to move this to the "2 year after take-over" mail Dec 1st -->
+We'd also like to commemorate Robbert Müller, co-maintainer of the PHP_CodeSniffer Composer Installer plugin, who passed away at the age of 46 this July.


### PR DESCRIPTION
# Description

This PR is intended to allow for conversation about the "press release"/mail to funders to accompany the PHP_CodeSniffer 4.0 release.

At this time, the text is just some draft notes to get the conversation started.
