### PR TITLE
CI: fix markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -43,6 +43,8 @@ config:
   MD036: false
   # MD041/first-line-heading/first-line-h1 : First line in a file should be a top-level heading.
   MD041: false
+  # MD060/table-column-style - Table column style.
+  MD060: false
 
   ##############################
   # Customize a few other rules.


### PR DESCRIPTION
# Description
MarkdownLint v0.39.0 introduced a new rule regarding table formatting.

While the principle of the rule is actually quite nice, it doesn't play nice with some of the tables in the PHPCS 4.0 upgrade guides, and while those files could, of course, be updated, that wouldn't improve the maintainability of the tables.

So, for now, I'm electing to ignore the new rule (`MD060`).

Refs:
* https://github.com/DavidAnson/markdownlint/blob/v0.39.0/CHANGELOG.md#0390
* https://github.com/DavidAnson/markdownlint/blob/main/doc/md060.md

