### PR TITLE
GH Actions: pin re-usable workflows too

### DIFF
--- a/.github/workflows/basic-qa.yml
+++ b/.github/workflows/basic-qa.yml
@@ -16,13 +16,13 @@ concurrency:
 jobs:
   yamllint:
     name: 'Lint Yaml'
-    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@9d51cbe2ff0bde5f7f5b2cf7608e9e13d593c6f2 # v1.0.0
     with:
       strict: true
 
   markdownlint:
     name: 'Lint Markdown'
-    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@9d51cbe2ff0bde5f7f5b2cf7608e9e13d593c6f2 # v1.0.0
 
   linkcheck:
     name: "Check links"


### PR DESCRIPTION
# Description
Follow up on #57, which added commit hash pinning to all externally managed action runners, this commit now also adds this to the re-usable workflows managed in the `PHPCSStandards/.github` repository.
