### PR TITLE
Customisable-Sniff-Properties: remove PSR12/OperatorSpacing sniff section

### DIFF
--- a/wiki/Customisable-Sniff-Properties.md
+++ b/wiki/Customisable-Sniff-Properties.md
@@ -1096,19 +1096,11 @@ This sniff checks the depth of imported namespaces inside compound use statement
 <p align="right"><a href="#table-of-contents">back to top</a></p>
 
 
-### PSR12.Operators.OperatorSpacing
-
-| Property Name                  | Type | Default | Available Since |
-| ------------------------------ | ---- | ------- | --------------- |
-| ignoreNewlines                 | bool | false   | 3.3.0           |
-| ignoreSpacingBeforeAssignments | bool | true    | 3.5.0           |
-
-> [!NOTE]
-> All properties are inherited from the [Squiz.WhiteSpace.OperatorSpacing](#squizwhitespaceoperatorspacing) sniff, although the default value of `allowMultipleArguments` is changed.
-
-See the [Squiz.WhiteSpace.OperatorSpacing](#squizwhitespaceoperatorspacing) sniff for an explanation of all properties.
-
-<p align="right"><a href="#table-of-contents">back to top</a></p>
+<!--
+While PSR12.Operators.OperatorSpacing inherits the `ignoreNewlines` and `ignoreSpacingBeforeAssignments` properties
+from the `Squiz.WhiteSpace.OperatorSpacing` sniff, these properties are not handled in the PSR12 sniff,
+so are deliberately not mentioned in this documentation.
+-->
 
 
 ## Squiz Sniffs


### PR DESCRIPTION
# Description
As per the inline comment replacing the section:

> While PSR12.Operators.OperatorSpacing inherits the `ignoreNewlines` and `ignoreSpacingBeforeAssignments` properties
> from the `Squiz.WhiteSpace.OperatorSpacing` sniff, these properties are not handled in the PSR12 sniff,
> so are deliberately not mentioned in this documentation.


## Related issues/external references

Discovered while reviewing upstream PR https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/1356


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation/blob/main/CONTRIBUTING.md).
- [x] I grant the project the right to include my changes under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have verified that my changes comply with the projects coding standards.
- [ ] \[When adding a new Wiki page\] I have added the new page to the `_Sidebar.md` file.
- [ ] \[When adding/updating output examples\] I have verified via the GitHub Actions artifact that the pre-processing handles the command correctly.
