### PR TITLE
feat(PSR12.Operators.OperatorSpacing): Add documentation for perCompatible setting

### DIFF
--- a/wiki/Customisable-Sniff-Properties.md
+++ b/wiki/Customisable-Sniff-Properties.md
@@ -1121,16 +1121,13 @@ By setting the `perCompatible` property to `'3.0'`or higher, the behaviour of th
 </rule>
 ```
 
-Valid: no spaces around the '|' operator in a multi-catch with 'perCompatible=3.0' (or higher):
+Example:
 ```php
 try {
+// Valid with setting perCompatible >= 3.0.
 } catch (Exception|RuntimeException $e) {
-}
-```
-Invalid: spaces around the '|' operator in a multi-catch with 'perCompatible=3.0' (or higher).
-```php
-try {
-} catch (Exception | RuntimeException $e) {
+// Valid with setting perCompatible < 3.0.
+} catch (OtherException | AnotherException $e) {
 }
 ```
 


### PR DESCRIPTION
Sister doc PR for https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/1356 

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation/blob/main/CONTRIBUTING.md).
- [x] I grant the project the right to include my changes under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have verified that my changes comply with the projects coding standards.