### PR TITLE
Requirements: document iconv as a recommended PHP extension

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -53,6 +53,9 @@ words:
   # Used in Wiki Reporting page, "emacs" file.
   - defun
 
+  # Used in Wiki Requirements page.
+  - multibyte
+
   # Used in CONTRIBUTING.
   - maxlevel
   - replacer

--- a/wiki/Requirements.md
+++ b/wiki/Requirements.md
@@ -6,4 +6,7 @@ Additionally, PHP_CodeSniffer requires the following PHP extensions to be enable
 - SimpleXML: used to process ruleset XML files
 - XMLWriter: used to create some report formats
 
+The following PHP extension is not required, but is strongly recommended:
+- iconv: used for accurate character length calculation in files containing multibyte characters. Without this extension, some sniffs, like `Generic.Files.LineLength`, may report incorrect results for lines containing non-ASCII characters, as PHP_CodeSniffer will fall back to byte-based length calculations.
+
 Individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) manual page for a list of these requirements.


### PR DESCRIPTION
# Description

As suggested in https://github.com/squizlabs/PHP_CodeSniffer/issues/3923#issuecomment-3824569465, this PR adds iconv to the Requirements wiki page as a strongly recommended PHP extension. Without it, PHP_CodeSniffer falls back to byte-based length calculations, which can cause sniffs like `Generic.Files.LineLength` to report incorrect results for files containing multibyte characters.

## Related issues/external references

Discussed in squizlabs/PHP_CodeSniffer#3923

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation/blob/main/CONTRIBUTING.md).
- [x] I grant the project the right to include my changes under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have verified that my changes comply with the projects coding standards.
- [ ] \[When adding a new Wiki page\] I have added the new page to the `_Sidebar.md` file.
- [ ] \[When adding/updating output examples\] I have verified via the GitHub Actions artifact that the pre-processing handles the command correctly.