### PR TITLE
Add pcntl and grpc docs

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -13,8 +13,8 @@ patterns:
     pattern: |
       /
           ^([\s>]*`{3,})[a-z]+  # match the ``` with a language modifier, optionally inside a blockquote
-          [\s\S]*?                  # the block of code
-          ^\1                       # end of the block
+          [\s\S]*?              # the block of code
+          ^\1                   # end of the block
       /gmx
   - name: markdown_inline_code
     pattern: /(\s*`)[^`\n]{3,}`/gmx

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -12,9 +12,9 @@ patterns:
   - name: markdown_code_block
     pattern: |
       /
-          ^(\s*`{3,})[a-z]+   # match the ``` with a language modifier
-          [\s\S]*?            # the block of code
-          ^\1                 # end of the block
+          ^((?:>\s*)?`{3,})[a-z]+  # match the ``` with a language modifier, optionally inside a blockquote
+          [\s\S]*?                  # the block of code
+          ^\1                       # end of the block
       /gmx
   - name: markdown_inline_code
     pattern: /(\s*`)[^`\n]{3,}`/gmx

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -12,7 +12,7 @@ patterns:
   - name: markdown_code_block
     pattern: |
       /
-          ^((?:>\s*)?`{3,})[a-z]+  # match the ``` with a language modifier, optionally inside a blockquote
+          ^([\s>]*`{3,})[a-z]+  # match the ``` with a language modifier, optionally inside a blockquote
           [\s\S]*?                  # the block of code
           ^\1                       # end of the block
       /gmx

--- a/wiki/Requirements.md
+++ b/wiki/Requirements.md
@@ -10,10 +10,10 @@ The following PHP extensions are not required, but are strongly recommended:
 - iconv: used for accurate character length calculation in files containing multibyte characters. Without this extension, some sniffs, like `Generic.Files.LineLength`, may report incorrect results for lines containing non-ASCII characters, as PHP_CodeSniffer will fall back to byte-based length calculations.
 - PCNTL: required for parallel processing via the `--parallel` CLI option. Without this extension, PHP_CodeSniffer will not be able to check multiple files simultaneously.
 
+Individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) manual page for a list of these requirements.
+
 > [!WARNING]
 > The gRPC PHP extension is known to cause PHP_CodeSniffer to hang when running with parallel processing enabled. If the gRPC extension is loaded, either do not use the `--parallel` CLI option or configure the extension's ini settings as follows:
 > ```text
 > phpcs -d grpc.enable_fork_support=1 -d grpc.poll_strategy=epoll1 [other options] <file|directory>
 > ```
-
-Individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) manual page for a list of these requirements.

--- a/wiki/Requirements.md
+++ b/wiki/Requirements.md
@@ -11,6 +11,9 @@ The following PHP extensions are not required, but are strongly recommended:
 - PCNTL: required for parallel processing via the `--parallel` CLI option. Without this extension, PHP_CodeSniffer will not be able to check multiple files simultaneously.
 
 > [!WARNING]
-> The gRPC PHP extension is known to cause PHP_CodeSniffer to hang when running with parallel processing enabled. If the gRPC extension is loaded, make sure the `grpc.enable_fork_support` and `grpc.poll_strategy` ini settings are properly configured. See [this comment](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/294#issuecomment-1906558549) for more details.
+> The gRPC PHP extension is known to cause PHP_CodeSniffer to hang when running with parallel processing enabled. If the gRPC extension is loaded, either do not use the `--parallel` CLI option or configure the extension's ini settings as follows:
+> ```
+> phpcs -d grpc.enable_fork_support=1 -d grpc.poll_strategy=epoll1 [other options] <file|directory>
+> ```
 
 Individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) manual page for a list of these requirements.

--- a/wiki/Requirements.md
+++ b/wiki/Requirements.md
@@ -6,7 +6,8 @@ Additionally, PHP_CodeSniffer requires the following PHP extensions to be enable
 - SimpleXML: used to process ruleset XML files
 - XMLWriter: used to create some report formats
 
-The following PHP extension is not required, but is strongly recommended:
+The following PHP extensions are not required, but are strongly recommended:
 - iconv: used for accurate character length calculation in files containing multibyte characters. Without this extension, some sniffs, like `Generic.Files.LineLength`, may report incorrect results for lines containing non-ASCII characters, as PHP_CodeSniffer will fall back to byte-based length calculations.
+- PCNTL: required for parallel processing via the `--parallel` CLI option. Without this extension, PHP_CodeSniffer will not be able to check multiple files simultaneously.
 
 Individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) manual page for a list of these requirements.

--- a/wiki/Requirements.md
+++ b/wiki/Requirements.md
@@ -12,7 +12,7 @@ The following PHP extensions are not required, but are strongly recommended:
 
 > [!WARNING]
 > The gRPC PHP extension is known to cause PHP_CodeSniffer to hang when running with parallel processing enabled. If the gRPC extension is loaded, either do not use the `--parallel` CLI option or configure the extension's ini settings as follows:
-> ```
+> ```text
 > phpcs -d grpc.enable_fork_support=1 -d grpc.poll_strategy=epoll1 [other options] <file|directory>
 > ```
 

--- a/wiki/Requirements.md
+++ b/wiki/Requirements.md
@@ -10,4 +10,7 @@ The following PHP extensions are not required, but are strongly recommended:
 - iconv: used for accurate character length calculation in files containing multibyte characters. Without this extension, some sniffs, like `Generic.Files.LineLength`, may report incorrect results for lines containing non-ASCII characters, as PHP_CodeSniffer will fall back to byte-based length calculations.
 - PCNTL: required for parallel processing via the `--parallel` CLI option. Without this extension, PHP_CodeSniffer will not be able to check multiple files simultaneously.
 
+> [!WARNING]
+> The gRPC PHP extension is known to cause PHP_CodeSniffer to hang when running with parallel processing enabled. If the gRPC extension is loaded, make sure the `grpc.enable_fork_support` and `grpc.poll_strategy` ini settings are properly configured. See [this comment](https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/294#issuecomment-1906558549) for more details.
+
 Individual sniffs may have additional requirements such as external applications and scripts. See the [Configuration Options](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options) manual page for a list of these requirements.


### PR DESCRIPTION
# Description

Follow-up to #91.

This PR introduces two changes to the Requirements wiki page:
- Documents PCNTL as a strongly recommended PHP extension, as it is required for parallel processing via the `--parallel` CLI option.
- Adds a warning about the gRPC PHP extension, which is known to cause PHP_CodeSniffer to hang when parallel processing is enabled.

## Related issues/external references

- https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation/pull/91#pullrequestreview-2718779966
- PHPCSStandards/PHP_CodeSniffer#294


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer-documentation/blob/main/CONTRIBUTING.md).
- [x] I grant the project the right to include my changes under the BSD-3-Clause license (and I have the right to grant these rights).
- [x] I have verified that my changes comply with the projects coding standards.
- [ ] \[When adding a new Wiki page\] I have added the new page to the `_Sidebar.md` file.
- [ ] \[When adding/updating output examples\] I have verified via the GitHub Actions artifact that the pre-processing handles the command correctly.

