### PR TITLE
GH Actions: fail "setup-php" if requested tooling could not be installed

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -54,6 +54,8 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On, log_errors_max_len=0
           tools: phpcs, phpcbf
           coverage: none
+        env:
+          fail-fast: true
 
       # Make sure we've gotten the latest PHPCS version from setup-php.
       - name: Retrieve latest release info


### PR DESCRIPTION
# Description
Setup-PHP will normally "gracefully" show a warning and not fail the build when an extension or tool failed to install.

In most cases, this is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be tested.

This commit changes this behaviour to fail select builds at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional
